### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
             password: ${{ secrets.GITHUB_TOKEN }}          
         -
           name: Build and push
-          uses: docker/build-push-action@v6.1.0
+          uses: docker/build-push-action@v6.2.0
           with:
             context: .
             platforms: linux/386,linux/amd64,linux/arm64,linux/ppc64le,linux/riscv64


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.2.0](https://github.com/docker/build-push-action/releases/tag/v6.2.0)** on 2024-06-26T13:09:11Z
