### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -80,7 +80,7 @@ jobs:
       - # Add support for more platforms with QEMU (optional)
         # https://github.com/docker/setup-qemu-action
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.5.0
+        uses: docker/setup-qemu-action@v3.6.0
       - # https://github.com/docker/setup-buildx-action/issues/57#issuecomment-1059657292
         # https://github.com/docker/buildx/issues/136#issuecomment-550205439
         # docker buildx create --driver-opt env.http_proxy=$http_proxy --driver-opt env.https_proxy=$https_proxy --driver-opt '"env.no_proxy='$no_proxy'"'

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -80,7 +80,7 @@ jobs:
       - # Add support for more platforms with QEMU (optional)
         # https://github.com/docker/setup-qemu-action
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.5.0
+        uses: docker/setup-qemu-action@v3.6.0
       - # https://github.com/docker/setup-buildx-action/issues/57#issuecomment-1059657292
         # https://github.com/docker/buildx/issues/136#issuecomment-550205439
         # docker buildx create --driver-opt env.http_proxy=$http_proxy --driver-opt env.https_proxy=$https_proxy --driver-opt '"env.no_proxy='$no_proxy'"'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/setup-qemu-action](https://github.com/docker/setup-qemu-action)** published a new release **[v3.6.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.6.0)** on 2025-02-28T12:55:32Z
